### PR TITLE
フォント検索関数を変更

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,8 @@
 
 #include "Fcpp.hpp"
 
+/// フォントファミリーにマッチしたフォントのパスを返す．
+/// フォントファミリーは第一引数にて受け取る．
 /// usage: findFont "font family name"
 int main(int argc, char* argv[]) {
     FcInit();
@@ -22,7 +24,7 @@ int main(int argc, char* argv[]) {
         {FC_FAMILY, (const FcChar8*)(argv[1])}
     });
 
-    const auto FoundFath = Fcpp::SearchFont(Fcpp::CurrentDefaultConfig(), SearchPattern);
+    const auto FoundFath = Fcpp::SearchFont(SearchPattern);
     if(!FoundFath.empty()) {
         std::cout << FoundFath.generic_string() << std::endl;
     }

--- a/example/findFont.cpp
+++ b/example/findFont.cpp
@@ -17,7 +17,7 @@ int main(int argc, char* argv[]) {
         {FC_FAMILY, (const FcChar8*)(argv[1])}
     });
 
-    const auto FoundFath = Fcpp::SearchFont(Fcpp::CurrentDefaultConfig(), SearchPattern);
+    const auto FoundFath = Fcpp::SearchFont(SearchPattern);
     if(!FoundFath.empty()) {
         std::cout << FoundFath.generic_string() << std::endl;
     }

--- a/include/Fcpp.hpp
+++ b/include/Fcpp.hpp
@@ -30,6 +30,5 @@ namespace Fcpp {
     }
 
     const std::filesystem::path SearchFont(const Pattern& pattern, const Config& conf = nullptr) noexcept;
-    const Config CurrentDefaultConfig() noexcept;
     const Pattern CreatePattern(const std::map<std::string, std::basic_string<FcChar8>>& param) noexcept;
 }

--- a/include/Fcpp.hpp
+++ b/include/Fcpp.hpp
@@ -29,7 +29,7 @@ namespace Fcpp {
         return Fc_ptr<return_type_raw>(Func(args...), false);
     }
 
-    const std::filesystem::path SearchFont(const Config& conf, const Pattern& pattern) noexcept;
+    const std::filesystem::path SearchFont(const Pattern& pattern, const Config& conf = nullptr) noexcept;
     const Config CurrentDefaultConfig() noexcept;
     const Pattern CreatePattern(const std::map<std::string, std::basic_string<FcChar8>>& param) noexcept;
 }

--- a/include/Fcpp.hpp
+++ b/include/Fcpp.hpp
@@ -29,6 +29,18 @@ namespace Fcpp {
         return Fc_ptr<return_type_raw>(Func(args...), false);
     }
 
+    /**
+     * @brief フォントを探す
+     * @param pattern 検索に用いるパターン
+     * @param conf 検索に用いるコンフィグ．nullptrの場合は現在のコンフィグが使われる．
+     * @return 見つけたフォントのファイルパス．空の場合は検索失敗．
+     */
     const std::filesystem::path SearchFont(const Pattern& pattern, const Config& conf = nullptr) noexcept;
+
+    /**
+     * @brief パターンを生成する
+     * @param param パターンに追加するプロパティの一覧
+     * @return 生成されたパターン
+     */
     const Pattern CreatePattern(const std::map<std::string, std::basic_string<FcChar8>>& param) noexcept;
 }

--- a/src/Fcpp.cpp
+++ b/src/Fcpp.cpp
@@ -55,10 +55,6 @@ const std::filesystem::path Fcpp::SearchFont(const Pattern& pattern, const Confi
     return std::filesystem::path((char*)filePaht);
 };
 
-const Fcpp::Config Fcpp::CurrentDefaultConfig() noexcept {
-    return Config(FcConfigGetCurrent());
-}
-
 const Fcpp::Pattern Fcpp::CreatePattern(const std::map<std::string, std::basic_string<FcChar8>>& param) noexcept {
     Pattern pattern = CreateFcPtr<FcPatternCreate>();
     if(pattern.get() == nullptr) {

--- a/src/Fcpp.cpp
+++ b/src/Fcpp.cpp
@@ -41,7 +41,7 @@ namespace {
     }
 }
 
-const std::filesystem::path Fcpp::SearchFont(const Config& conf, const Pattern& pattern) noexcept {
+const std::filesystem::path Fcpp::SearchFont(const Pattern& pattern, const Config& conf) noexcept {
     const auto SearchPattern = SubstitutePattern(conf, pattern);
     if (!SearchPattern) {
         return "";


### PR DESCRIPTION
- パターンの置換関数を追加した
- 置換時のエラーを処理するようにした
- フォント検索関数の引数を省略できるようにした
- これらの変更をサンプルコードに適用した